### PR TITLE
Add --assume-impl-partialeq <regex> flag

### DIFF
--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -521,6 +521,12 @@ where
                 .value_name("regex")
                 .multiple_occurrences(true)
                 .number_of_values(1),
+            Arg::new("assume-impl-partialeq")
+                .long("assume-impl-partialeq")
+                .help("Assume PartialEq for types matching <regex>.")
+                .value_name("regex")
+                .multiple_occurrences(true)
+                .number_of_values(1),
             Arg::new("must-use-type")
                 .long("must-use-type")
                 .help("Add #[must_use] annotation to types matching <regex>.")
@@ -1043,6 +1049,14 @@ where
     if let Some(no_hash) = matches.values_of("no-hash") {
         for regex in no_hash {
             builder = builder.no_hash(regex);
+        }
+    }
+
+    if let Some(assume_impl_partialeq) =
+        matches.values_of("assume-impl-partialeq")
+    {
+        for regex in assume_impl_partialeq {
+            builder = builder.assume_impl_partialeq(regex);
         }
     }
 

--- a/bindgen-tests/tests/expectations/tests/assume-impl-partialeq.rs
+++ b/bindgen-tests/tests/expectations/tests/assume-impl-partialeq.rs
@@ -1,0 +1,86 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+impl PartialEq for AssumePartialEq {
+    fn eq(&self, other: &Self) -> bool {
+        self.bar == other.bar
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AssumePartialEq {
+    pub bar: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_AssumePartialEq() {
+    const UNINIT: ::std::mem::MaybeUninit<AssumePartialEq> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<AssumePartialEq>(),
+        4usize,
+        concat!("Size of: ", stringify!(AssumePartialEq))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<AssumePartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AssumePartialEq))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AssumePartialEq),
+            "::",
+            stringify!(bar)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct UsesAssumePartialEq {
+    pub foo: AssumePartialEq,
+    pub baz: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_UsesAssumePartialEq() {
+    const UNINIT: ::std::mem::MaybeUninit<UsesAssumePartialEq> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<UsesAssumePartialEq>(),
+        8usize,
+        concat!("Size of: ", stringify!(UsesAssumePartialEq))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<UsesAssumePartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(UsesAssumePartialEq))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesAssumePartialEq),
+            "::",
+            stringify!(foo)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesAssumePartialEq),
+            "::",
+            stringify!(baz)
+        )
+    );
+}

--- a/bindgen-tests/tests/headers/assume-impl-partialeq.h
+++ b/bindgen-tests/tests/headers/assume-impl-partialeq.h
@@ -1,0 +1,18 @@
+// bindgen-flags: --with-derive-partialeq --assume-impl-partialeq AssumePartialEq --raw-line "impl PartialEq for AssumePartialEq { fn eq(&self, other: &Self) -> bool { self.bar == other.bar } }"
+
+/*
+ * Normally AssumePartialEq will derive PartialEq but assume-impl-partialeq will
+ * prevent that from happening
+ */
+struct AssumePartialEq {
+  int bar;
+};
+
+/*
+ * UsesAssumePartialEq should derive PartialEq because we assume that AssumePartialEq
+ * will provide an impl for PartialEq
+ */
+struct UsesAssumePartialEq {
+  struct AssumePartialEq foo;
+  int baz;
+};

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -2702,6 +2702,12 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         self.options().no_hash_types.matches(&name)
     }
 
+    /// Check if `--assume-impl-partialeq` flag is enabled for this item.
+    pub fn assume_impl_partialeq_by_name(&self, item: &Item) -> bool {
+        let name = item.path_for_allowlisting(self)[1..].join("::");
+        self.options().assume_impl_partialeq_types.matches(&name)
+    }
+
     /// Check if `--must-use-type` flag is enabled for this item.
     pub fn must_use_type_by_name(&self, item: &Item) -> bool {
         let name = item.path_for_allowlisting(self)[1..].join("::");

--- a/bindgen/ir/derive.rs
+++ b/bindgen/ir/derive.rs
@@ -94,6 +94,9 @@ pub trait CanDeriveOrd {
 /// update our understanding as we learn more about each type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CanDerive {
+    /// Assume already derived
+    AssumeYes,
+
     /// Yes, we can derive automatically.
     Yes,
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -357,6 +357,10 @@ impl Builder {
             (&self.options.no_debug_types, "--no-debug"),
             (&self.options.no_default_types, "--no-default"),
             (&self.options.no_hash_types, "--no-hash"),
+            (
+                &self.options.assume_impl_partialeq_types,
+                "--assume-impl-partialeq",
+            ),
             (&self.options.must_use_types, "--must-use-type"),
         ];
 
@@ -1707,6 +1711,13 @@ impl Builder {
         self
     }
 
+    /// Assume an impl for `PartialEq` exists for a given type.
+    /// Regular expressions are supported.
+    pub fn assume_impl_partialeq<T: Into<String>>(mut self, arg: T) -> Builder {
+        self.options.assume_impl_partialeq_types.insert(arg.into());
+        self
+    }
+
     /// Add `#[must_use]` for the given type. Regular
     /// expressions are supported.
     pub fn must_use_type<T: Into<String>>(mut self, arg: T) -> Builder {
@@ -2066,6 +2077,9 @@ struct BindgenOptions {
     /// The set of types that we should not derive `Hash` for.
     no_hash_types: RegexSet,
 
+    /// The set of types assumed to have `PartialEq` for.
+    assume_impl_partialeq_types: RegexSet,
+
     /// The set of types that we should be annotated with `#[must_use]`.
     must_use_types: RegexSet,
 
@@ -2141,6 +2155,7 @@ impl BindgenOptions {
             &mut self.no_debug_types,
             &mut self.no_default_types,
             &mut self.no_hash_types,
+            &mut self.assume_impl_partialeq_types,
             &mut self.must_use_types,
         ];
         let record_matches = self.record_matches;
@@ -2249,6 +2264,7 @@ impl Default for BindgenOptions {
             no_debug_types: Default::default(),
             no_default_types: Default::default(),
             no_hash_types: Default::default(),
+            assume_impl_partialeq_types: Default::default(),
             must_use_types: Default::default(),
             array_pointers_in_arguments: false,
             wasm_import_module_name: None,


### PR DESCRIPTION
Add an ability to defer the derivation of traits for certain types but still make the codegen believe that the type impls the trait. 
This is beneficial in situations where a certain type A needs a custom trait impl but the types downstream B that depend on type A can use the trivial derive impls. Without this, all the downstream dependencies of A will have to manually impl traits that could be easily derived. This become difficult when there are lots of downstream types that are affected.

e.g.
```
// needs custom impl PartialEq
struct A;

impl PartialEq for A { ... }

#[derive(PartialEq)]
struct B {
  a: A,
  ...
}
```